### PR TITLE
Create basic CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: Build specification
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: build pdf and html
+    runs-on: ubuntu-latest
+    environment: pr_ci
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt-get install -y librsvg2-bin python3-sphinx latexmk texlive-latex-extra
+      - run: make latexpdf
+      - run: make html
+
+      - name: Archive pdf
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmware_handoff.pdf
+          path: build/latex/Firmware_handoff.pdf


### PR DESCRIPTION
The CI script contains a single job executed at a PR:
 - installs all dependencies on Ubuntu latest
 - builds pdf
 - builds html

The job runs in the pr_ci environment.
The expectation is that this environment requires the maintainer team to release the job (relies on the GitHub project configuration).