### PR TITLE
Use lower case filename in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,4 +20,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: firmware_handoff.pdf
-          path: build/latex/Firmware_handoff.pdf
+          path: build/latex/firmware_handoff.pdf


### PR DESCRIPTION
The changes in #1 caused the pdf archiving in the CI to fail. Use lower case output filename to match the changes in #1.
