### PR TITLE
Set the document version to 0.9

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -26,7 +26,7 @@ author = 'Firmware handoff contributors'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.1'
+release = '0.9'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
As agreed, the document will be initially released at a 0.9 version. We will move the document version to 1.0 once enough implementations of exist and we have confidence in the specification definition.

Change-Id: I2645b8bbf9522f51ac926313af71431b48153da4