### PR TITLE
Fix relocation algorithm description

### DIFF
--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -346,7 +346,9 @@ Inputs:
 
 #. Calculate `alignment_mask` as `(1 << tl.alignment) - 1`.
 
-#. Calculate `new_tl_base` as `(target_base + alignment_mask) & ~alignment_mask`.
+#. Calculate the current `alignment_offset` as `tl_base_addr & alignment_mask`.
+
+#. Calculate `new_tl_base` as `(target_base & ~alignment_mask) + alignment_offset`.
 
 #. If `new_tl_base` is below `target_base`, add `alignment_mask + 1` to `new_tl_base`.
 
@@ -358,7 +360,7 @@ Inputs:
 #. Subtract the sum of the 4 bytes from `new_tl_base + 0xc` to `new_tl_base + 0x10`
    from `tl.checksum` (`new_tl_base + 0x4`).
 
-#. Set `tl.max_size` (`new_tl_base + 0xc`) to `target_size - new_tl_base`.
+#. Set `tl.max_size` (`new_tl_base + 0xc`) to `target_size - (new_tl_base - target_base)`.
 
 #. Add the sum of the 4 bytes from `new_tl_base + 0xc` to `new_tl_base + 0x10`
    to `tl.checksum` (`new_tl_base + 0x4`).


### PR DESCRIPTION
This patch fixes a mistake that crept in during review of PR #6 (patch 062d542). The `alignment_offset` calculated from `tl_base_addr` was not superfluous in that calculation -- in fact, this is the only way in which `tl_base_addr` entered the calculation at all. If we don't have this, relocation for base addresses that do not already happen to match the highest alignment requirement won't work.

Also fix another small mistake in the same algorithm regarding calculating the new `tl.max_size`.