### PR TITLE
Change checksum to 4a0f_b10b

### DIFF
--- a/source/register_conventions.rst
+++ b/source/register_conventions.rst
@@ -55,7 +55,7 @@ absent from the transfer list.
    +--------------+-------------------------------------------------------------+
    | X1           | X1 is divided into the following fields:                    |
    |              |                                                             |
-   |              | - X1[23:0]: set to the TL signature (0x40_b10b)             |
+   |              | - X1[23:0]: set to the TL signature (4a0f_b10b)             |
    |              | - X1[31:24]: version of the register convention used. Set to|
    |              |   1 for the AArch64 convention specified in this document.  |
    |              | - X1[63:32]: reserved, must be zero.                        |
@@ -101,7 +101,7 @@ absent from the transfer list.
    +--------------+-------------------------------------------------------------+
    | R1           | R1 is divided into the following fields:                    |
    |              |                                                             |
-   |              | - R1[23:0]: set to the TL signature (0x40_b10b)             |
+   |              | - R1[23:0]: set to the TL signature (4a0f_b10b)             |
    |              | - X1[31:24]: version of the register convention used. Set to|
    |              |   1 for the AArch32 convention specified in this document.  |
    |              |                                                             |

--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -48,7 +48,7 @@ Transfer list header
 
 A TL must begin with a TL header. The layout of the TL header is shown in
 :numref:`tab_tl_header`.  The presence of a TL header can be verified by
-inspecting the signature field which must contain the 0x40_b10b value.  The
+inspecting the signature field which must contain the 4a0f_b10b value.  The
 
 version field determines the contents of the handoff start header. The version
 will only be changed by an update to this specification when new TL header or
@@ -67,7 +67,7 @@ changes will be backwards-compatible to older readers.
    * - signature
      - 0x4
      - 0x0
-     - The value of signature must be `0x40_b10b`.
+     - The value of signature must be `4a0f_b10b`.
 
    * - checksum
      - 0x1
@@ -199,7 +199,7 @@ Inputs:
 
 - `tl_base_addr`: Base address of the existing TL.
 
-#. Compare `tl.signature` (`tl_base_addr + 0x0`) to `0x40_b10b`. On a mismatch,
+#. Compare `tl.signature` (`tl_base_addr + 0x0`) to `4a0f_b10b`. On a mismatch,
    abort (this is not a valid TL).
 
 #. Compare `tl.version` (`tl_base_addr + 0x5`) to the expected version
@@ -353,7 +353,7 @@ Inputs:
 
 #. Check that `available_size` is larger than `0x18` (the assumed `tl.hdr_size`), otherwise abort.
 
-#. Set `tl.signature` (`tl_base_addr + 0x0`) to `0x40_b10b`.
+#. Set `tl.signature` (`tl_base_addr + 0x0`) to `4a0f_b10b`.
 
 #. Set `tl.checksum` (`tl_base_addr + 0x4`) to `0x0` (for now).
 


### PR DESCRIPTION
The current signature value is 0x40_b10b

We actually have 4 bytes for the signature, so having one byte as zero is not ideal.

Adopt 4a0f_b10b (meaning "handoff blob") instead.


Fixes: #21