### PR TITLE
Adjust terminoloy for size

### DIFF
--- a/source/images/handoff_list_diagram.svg
+++ b/source/images/handoff_list_diagram.svg
@@ -304,7 +304,7 @@ span.MathJax_SVG { position: static !important; }</xhtml:style>
       <text
          x="461.22458"
          y="497.43219"
-         id="text36">tl_base_pa + TL.length</text>
+         id="text36">tl_base_pa + TL.used_size</text>
     </g>
     <rect
        x="125"
@@ -582,7 +582,7 @@ span.MathJax_SVG { position: static !important; }</xhtml:style>
       <text
          x="470.53601"
          y="576.81146"
-         id="text132">tl_base_pa + TL.max_length</text>
+         id="text132">tl_base_pa + TL.total_size</text>
     </g>
     <path
        d="m 380,575 h 10"


### PR DESCRIPTION
The word 'size' is pretty generic and appears through the spec. It refers to the about of space currently used by the TEs, so rename it to used_size

The term `max_size` is a little confusing since it is really the current size of the TL including its spare space. Rename this to total_size indicating that is the total of all TEs and space space.

It also happens to match the devicetree terminology.

Fixes: #22