### PR TITLE
Fix OP-TEE pageable part data size

### DIFF
--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -862,7 +862,7 @@ the OP-TEE OS.
      - The size (in bytes) of the address of OP-TEE pageable part which must be set to **8**.
 
    * - pp_addr
-     - data_size
+     - 0x8
      - hdr_size
      - Holds the address of OP-TEE pageable part
 


### PR DESCRIPTION
`pp_addr` is a 64-bit address, using `data_size` in its size field implies that it is variable sized. Replace the variable with its fixed size for clarity.