### PR TITLE
Fix embedded hyperlinks in references

### DIFF
--- a/source/references.rst
+++ b/source/references.rst
@@ -13,16 +13,16 @@
 References
 ==========
 
-.. [DT] `Devicetree Specification <https://www.devicetree.org/specifications/>`
+.. [DT] `Devicetree Specification <https://www.devicetree.org/specifications/>`__
 
-.. [PI] `Volume 3:Platform Initialization -- Shared Architectural Elements`, UEFI forum
+.. [PI] Volume 3:Platform Initialization -- Shared Architectural Elements, `UEFI forum <https://uefi.org/specifications>`__
 
-.. [ACPI] `Advanced Configuration and Power Interface (ACPI) Specification.`
+.. [ACPI] Advanced Configuration and Power Interface (ACPI) Specification, `UEFI forum <https://uefi.org/specifications>`__
 
-.. [ArmARM] `Arm® Architecture Reference Manual for the A-profile architecture`, Arm LTD.
+.. [ArmARM] Arm® Architecture Reference Manual for the A-profile architecture, `ARM DDI0487 <https://developer.arm.com/documentation/ddi0487>`__
 
-.. [OPTEECore] `OP-TEE Core <https://optee.readthedocs.io/en/latest/architecture/core.html>`
+.. [OPTEECore] `OP-TEE Core Architecture <https://optee.readthedocs.io/en/latest/architecture/core.html>`__
 
-.. [TFAFFAMB] `TF-A Secure Partition Manager: FF-A manifest binding to device tree <https://trustedfirmware-a.readthedocs.io/en/latest/components/ffa-manifest-binding.html>`
+.. [TFAFFAMB] TF-A Secure Partition Manager: `FF-A manifest binding to device tree <https://trustedfirmware-a.readthedocs.io/en/latest/components/ffa-manifest-binding.html>`__
 
-.. [TCG_EFI] `https://trustedcomputinggroup.org/resource/tcg-efi-protocol-specification`.
+.. [TCG_EFI] `Trusted Computing Group EFI Protocol Specification <https://trustedcomputinggroup.org/resource/tcg-efi-protocol-specification>`__


### PR DESCRIPTION
Each of the footnote references either had broken hyperlink syntax or no hyperlink at all. Add/fix links as appropriate.