### PR TITLE
Move up GitHub actions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pr_ci
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           sudo apt-get update
           sudo apt-get install -y librsvg2-bin \
@@ -21,7 +21,7 @@ jobs:
       - run: make html
 
       - name: Archive pdf
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: firmware_handoff.pdf
           path: build/latex/firmware_handoff.pdf


### PR DESCRIPTION
Move up GitHub actions version to v4 in main.yml to avoid build warning, as per:
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions