### PR TITLE
Fix tag ID of RW memory layout entry

### DIFF
--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -972,7 +972,7 @@ into its memory map during platform setup. If other memory types are required
    * - tag_id
      - 0x3
      - 0x0
-     - The tag_id field must be set to **104**.
+     - The tag_id field must be set to **0x104**.
 
    * - hdr_size
      - 0x1


### PR DESCRIPTION
Tag ID of RW memory layout entry was wrongly put as "104" instead of "0x104".