### PR TITLE
Fix register convention for 4 byte signature

### DIFF
--- a/source/register_conventions.rst
+++ b/source/register_conventions.rst
@@ -30,7 +30,7 @@ In this register convention, the pointer to the 64-bit tl_base_pa address is pas
 
 Register X2 must be set to 0.
 
-The 24 least significant bits in register X1 contains the TL signature. The
+The 32 least significant bits in register X1 contains the TL signature. The
 *signature* provides guarantees to a receiver that X3 holds the *tl_base_pa*. The
 bits [39:32] of X1 contain the version of the register convention being used.
 :numref:`tab_aarch64_convention` specifies the version 1 of the AArch64 handoff register convention.
@@ -55,10 +55,10 @@ absent from the transfer list.
    +--------------+-------------------------------------------------------------+
    | X1           | X1 is divided into the following fields:                    |
    |              |                                                             |
-   |              | - X1[23:0]: set to the TL signature (4a0f_b10b)             |
-   |              | - X1[31:24]: version of the register convention used. Set to|
+   |              | - X1[31:0]: set to the TL signature (4a0f_b10b)             |
+   |              | - X1[39:32]: version of the register convention used. Set to|
    |              |   1 for the AArch64 convention specified in this document.  |
-   |              | - X1[63:32]: reserved, must be zero.                        |
+   |              | - X1[63:40]: reserved, must be zero.                        |
    |              |                                                             |
    +--------------+-------------------------------------------------------------+
    | X2           | Reserved, must be zero.                                     |
@@ -79,11 +79,11 @@ tl_base_pa address is passed on register R3.
 Register R1 contains the TL signature, to provide guarantees to a receiver that
 R3 holds the tl_base_pa.
 
-The 24 least significant bits in register R1 contains the TL signature. The
-signature provides guarantees to a receiver that X3 holds the tl_base_pa. The
-8 most significant bits of R1 contain the version of the register convention
-being used. Table 4 specifies the version 1 of the AArch32 handoff register
-convention.
+The 24 least significant bits in register R1 contains the 24 least significant
+bits of TL signature. The signature provides guarantees to a receiver that X3
+holds the tl_base_pa. The 8 most significant bits of R1 contain the version of
+the register convention being used. Table 4 specifies the version 1 of the AArch32
+handoff register convention.
 
 Register R2 must hold a pointer to the hardware description devicetree, if the
 transfer list contains an FDT entry. This field is set to 0 if an fdt entry is
@@ -101,7 +101,8 @@ absent from the transfer list.
    +--------------+-------------------------------------------------------------+
    | R1           | R1 is divided into the following fields:                    |
    |              |                                                             |
-   |              | - R1[23:0]: set to the TL signature (4a0f_b10b)             |
+   |              | - R1[23:0]: set to the 24 least significant bits of TL      |
+                      signature (0f_b10b).                                      |
    |              | - R1[31:24]: version of the register convention used. Set to|
    |              |   1 for the AArch32 convention specified in this document.  |
    |              |                                                             |


### PR DESCRIPTION
Commit d6afd9b updated the signature from 3 bytes to 4 bytes, but didn't update the register_conventions accordingly.

For AArch64 mode represent whole 4 bytes of signature in register X1 while for AArch32 mode use only 3 least significant bytes of signature.