### PR TITLE
FF-A manifest and SP binary TE types

### DIFF
--- a/source/references.rst
+++ b/source/references.rst
@@ -28,3 +28,5 @@ References
 .. [TCG_EFI] `Trusted Computing Group EFI Protocol Specification <https://trustedcomputinggroup.org/resource/tcg-efi-protocol-specification>`__
 
 .. [TF_BL31] `Data structures used in the BL31 cold boot interface <https://trustedfirmware-a.readthedocs.io/en/latest/design/firmware-design.html#data-structures-used-in-the-bl31-cold-boot-interface>`__
+
+.. [SPMCATTR] `The SPMC manifest: <https://hafnium.readthedocs.io/en/latest/secure-partition-manager/secure-partition-manager.html#spmc-manifest>`__

--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -1032,6 +1032,44 @@ into its memory map during platform setup. If other memory types are required
      - hdr_size + 0x8
      - The size of the memory region.
 
+**DT formatted FF-A manifest entry layout (XFERLIST_DT_FFA_MANIFEST)**
+
+This entry type holds the FF-A manifest image whice is in DT format [DT]_,
+as described in [TFAFFAMB]_.
+This manifest contains the SP (Secure Partition) configuration, consumed
+by the SPMC at boot time.
+
+It may also contain some information to the SP itself.
+
+.. _tab_dt_ffa_manifest:
+.. list-table:: DT formatted FF-A manifest type layout
+   :widths: 2 2 2 8
+
+   * - Field
+     - Size (bytes)
+     - Offset (bytes)
+     - Description
+
+   * - tag_id
+     - 0x3
+     - 0x0
+     - The tag_id field must be set to **0x106**.
+
+   * - hdr_size
+     - 0x1
+     - 0x3
+     - |hdr_size_desc|
+
+   * - data_size
+     - 0x4
+     - 0x4
+     - The size of FF-A manifest in bytes.
+
+   * - ffa_manifest
+     - data_size
+     - hdr_size
+     - Holds a FF-A manifest image in DT format.
+
 Mbed-TLS heap information (XFERLIST_MBEDTLS_HEAP_INFO)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1072,8 +1110,6 @@ passed to later stages for intialisation of Mbed-TLS.
      - 0x8
      - hdr_size + 0x8
      - Size of memory region.
-
-
 
 .. |hdr_size_desc| replace:: The size of this entry header in bytes must be set to **8**.
 .. |current_version| replace:: `0x1`

--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -951,6 +951,43 @@ software running in Secure, Non-Secure, or Realm modes.
      - hdr_size
      - Holds a single `entry_point_info` structure.
 
+**FF-A SP binary (XFERLIST_FFA_SP_BINARY)**
+
+This entry holds a reference to an FF-A Secure Partition (SP) binary.
+
+This TE type is for an SPMC implementation to identify which entry
+relates to the SP's binary, such that it can install the binary and
+hand-over execution.
+
+.. _tab_ffa_sp_binary:
+.. list-table:: An FF-A SP binary type layout
+   :widths: 2 2 2 8
+
+   * - Field
+     - Size (bytes)
+     - Offset (bytes)
+     - Description
+
+   * - tag_id
+     - 0x3
+     - 0x0
+     - The tag_id field must be set to **0x103**.
+
+   * - hdr_size
+     - 0x1
+     - 0x3
+     - |hdr_size_desc|
+
+   * - data_size
+     - 0x4
+     - 0x4
+     - The size of the SP binary in bytes.
+
+   * - ffa_sp_binary
+     - data_size
+     - hdr_size
+     - Holds the FF-A SP binary.
+
 **Read-Write Memory Layout Entry Layout (XFERLIST_RW_MEM_LAYOUT64)**
 
 This entry type holds a structure that describes the layout of a read-write

--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -826,7 +826,7 @@ Entries related to Trusted Firmware
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following entry types are defined for Trusted Firmware projects,
-including TF-A and OP-TEE:
+including TF-A, OP-TEE and Hafnium:
 
 **OP-TEE pageable part address entry layout (XFERLIST_OPTEE_PAGEABLE_PART_ADDR)**
 
@@ -868,9 +868,11 @@ the OP-TEE OS.
 **DT formatted SPMC manifest entry layout (XFERLIST_DT_SPMC_MANIFEST)**
 
 This entry type holds the SPMC (Secure Partition Manager Core) manifest image
-which is in DT format [DT]_ and described in [TFAFFAMB]_.
+which is in DT format [DT]_ and described in [SPMCATTR]_.
 This manifest contains the SPMC attribute node consumed by the SPMD
 (Secure Partition Manager Dispatcher) at boot time.
+It may also contain some information for the SPMC implementation, to
+initialize itself.
 
 .. _tab_dt_spmc_manifest:
 .. list-table:: DT formatted SPMC manifest type layout


### PR DESCRIPTION
The full rationale can be found in issue [51](https://github.com/FirmwareHandoff/firmware_handoff/issues/51).

This pull request concerns adding a dedicated data type for an SP binary and making the SPMC manifest TE type more generic, to be used as the SP's FF-A manifest.

This allows the Hafnium SPMC to use the TL format to package SP's artefacts.