### PR TITLE
Add nightly job to test doc builds and links

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,30 @@
+name: Nightly Sphinx Build and Link Check
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  # This allows the job to be manually triggered.
+  workflow_dispatch:
+
+jobs:
+  build-and-check-links:
+    name: "Build PDF and HTML documentation"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y librsvg2-bin \
+            python3-sphinx latexmk texlive-latex-extra \
+            python3-sphinxcontrib.svg2pdfconverter sphinx-multiversion \
+            python3-sphinx-rtd-theme
+
+      - name: Build Sphinx documentation
+        run: |
+          make html latexpdf
+
+      - name: Check for broken links
+        run: |
+          sphinx-build -b linkcheck source/ _build/linkcheck

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://github.com/FirmwareHandoff/firmware_handoff/actions/workflows/main.yml/badge.svg)](https://github.com/FirmwareHandoff/firmware_handoff/actions/workflows/main.yml)
+[![Daily Status](https://github.com/FirmwareHandoff/firmware_handoff/actions/workflows/daily.yml/badge.svg)](https://github.com/FirmwareHandoff/firmware_handoff/actions/workflows/daily.yml)
 [![Release Version](https://img.shields.io/github/v/release/FirmwareHandoff/firmware_handoff?label=release)](https://github.com/FirmwareHandoff/firmware_handoff/releases)
 
 This repository contains the Firmware Handoff specification, which defines a


### PR DESCRIPTION
Create a scheduled job to run nightly, ensuring documentation builds and links are validated and errors are caught early.

Fixes #64 