### PR TITLE
Ignore uefi.org links during linkcheck

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -69,6 +69,7 @@ exclude_patterns = []
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 
+linkcheck_ignore = [r'https://uefi\.org/specs/.*',]
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Adds linkcheck_ignore for https://uefi.org/specs/* URLs to avoid 403 errors [1] when checking links via GitHub CI. Site access appears restricted, causing false linkcheck failures.

[1] https://github.com/FirmwareHandoff/firmware_handoff/actions/runs/14632508665/job/41057250230#step:6:36