### PR TITLE
Add Trusted Boot Firmware Configuration entry

### DIFF
--- a/source/references.rst
+++ b/source/references.rst
@@ -23,7 +23,7 @@ References
 
 .. [OPTEECore] `OP-TEE Core Architecture v4.5 <https://optee.readthedocs.io/en/4.5.0/architecture/core.html>`__
 
-.. [TB_FW_CONFIG] `Trusted Boot Firmware Configuration bindings <https://trustedfirmware-a.readthedocs.io/en/latest/components/fconf/tb_fw_bindings.html>`__
+.. [TB_FW_CONFIG] `Trusted Boot Firmware Configuration bindings <https://review.trustedfirmware.org/plugins/gitiles/TF-A/trusted-firmware-a/+/c6c882a42795da82b18d2d7dff1265bf2a1a6aab/docs/components/fconf/tb_fw_bindings.rst>`__
 
 .. [TFAFFAMB] TF-A Secure Partition Manager: `FF-A manifest binding to device tree v2.12 <https://trustedfirmware-a.readthedocs.io/en/v2.12.0/components/ffa-manifest-binding.html>`__
 

--- a/source/references.rst
+++ b/source/references.rst
@@ -23,6 +23,8 @@ References
 
 .. [OPTEECore] `OP-TEE Core Architecture v4.5 <https://optee.readthedocs.io/en/4.5.0/architecture/core.html>`__
 
+.. [TB_FW_CONFIG] `Trusted Boot Firmware Configuration bindings <https://trustedfirmware-a.readthedocs.io/en/latest/components/fconf/tb_fw_bindings.html>`__
+
 .. [TFAFFAMB] TF-A Secure Partition Manager: `FF-A manifest binding to device tree v2.12 <https://trustedfirmware-a.readthedocs.io/en/v2.12.0/components/ffa-manifest-binding.html>`__
 
 .. [TCG_EFI] `Trusted Computing Group EFI Protocol Specification v15 <https://trustedcomputinggroup.org/wp-content/uploads/TCG_EFI_Platform_1_22_Final_-v15.pdf>`__

--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -883,6 +883,9 @@ including TF-A, OP-TEE and Hafnium.
    * - :ref:`0x109 <tab_gpt_info>`
      - GPT Error Info
 
+   * - :ref:`0x10a <tab_tb_fw_config>`
+     - DT Trusted Boot Firmware Configuration (``TB_FW_CONFIG``)
+
 **OP-TEE pageable part address entry layout (XFERLIST_OPTEE_PAGEABLE_PART_ADDR)**
 
 This entry type holds the address of OP-TEE pageable part which is described in
@@ -1415,6 +1418,44 @@ Bits [7:1] are reserved for future use.
      - data_size
      - hdr_size
      - The `gpt_error_info` field contains GPT error information.
+
+**DT Trusted Boot Firmware Configuration entry layout
+(XFERLIST_TB_FW_CONFIG)**
+
+The Trusted Boot Firmware Configuration (TB_FW_CONFIG) is a dynamic
+configuration file used in TF-A to configure properties relating to trusted
+firmware (i.e. IO policies, and Mbed TLS heap info) [TB_FW_CONFIG]_. This TE
+contains in its data section the configuration file in DT format [DT]_.
+
+.. _tab_tb_fw_config:
+.. list-table:: Trusted Boot Firmware Configuration entry type layout
+   :widths: 2 2 2 8
+
+   * - Field
+     - Size (bytes)
+     - Offset (bytes)
+     - Description
+
+   * - tag_id
+     - 0x3
+     - 0x0
+     - The tag_id field must be set to **0x10a**.
+
+   * - hdr_size
+     - 0x1
+     - 0x3
+     - |hdr_size_desc|
+
+   * - data_size
+     - 0x4
+     - 0x4
+     - The size of the configuration file in bytes.
+
+   * - tb_fw_config
+     - data_size
+     - hdr_size
+     - Holds a Trusted Boot Firmware Configuration file in DT format.
+
 
 .. |hdr_size_desc| replace:: The size of this entry header in bytes must be set to `8`.
 .. |current_version| replace:: `0x1`


### PR DESCRIPTION
Defines a TE type for passing the Trusted Boot Firmware Configuration (TB_FW_CONFIG) DT blob. Includes layout table, usage description, and references the TF-A bindings. Note, this DT format is platform specific, unstable and only used by TF-A BL1/BL2. It's content is not expected to make it's way to subsequent firmware stages. A binding document is provided as reference for what contents might be included by a platform.