### PR TITLE
glossary: Use proper U-Boot spelling

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -23,7 +23,7 @@ Firmware Handoff documentation.
       Application Processor
 
    Blob List
-      Bloblist is an U-boot implementation of the Firmware Handoff protocol
+      Bloblist is an U-Boot implementation of the Firmware Handoff protocol
 
    DT
       Device Tree


### PR DESCRIPTION
Fix inconsistent capitalization; "U-Boot" is the correct spelling.