### PR TITLE
Revert "Switch to an xor for the checksum"

### DIFF
--- a/source/transfer_list.rst
+++ b/source/transfer_list.rst
@@ -71,7 +71,7 @@ changes will be backwards-compatible to older readers.
    * - checksum
      - 0x1
      - 0x4
-     - If enabled by the flags, the checksum is used to provide basic protection against something overwriting the TL in memory. The checksum is set to a value such that the xor over every byte in the {`tl_base_pa`, …, `tl_base_pa + used_size - 1`} address range, is equal to `0`. For the purposes of this calculation, the value of this checksum field in the TL header must be assumed as `0`. Note that the checksum must include the TL header, all TEs and the inter-TE padding, but must not include the range reserved for future TE additions up to total_size. The values of inter-TE padding bytes are not defined by this specification and may be uninitialized memory. (This means that multiple TLs with exactly the same size and contents may still have different checksum values.). If checksums are not used, this must be `0`.
+     - If enabled by the flags, the checksum is used to provide basic protection against something overwriting the TL in memory. The checksum is set to a value such that the sum over every byte in the {`tl_base_pa`, …, `tl_base_pa + size - 1`} address range, modulo 256, is equal to 0. For the purposes of this calculation, the value of this checksum field in the TL header must be assumed as 0. Note that the checksum includes the TL header, all TEs and the inter-TE padding, but not the range reserved for future TE additions up to max_size. The values of inter-TE padding bytes are not defined by this specification and may be uninitialized memory. (This means that multiple TLs with exactly the same size and contents may still have different checksum values.). If checksums are not used, this must be 0.
 
    * - version
      - 0x1
@@ -318,8 +318,9 @@ Inputs:
    equal to the size of the total area reserved for the TL (if known). If not,
    abort (TL is corrupted).
 
-#. *(optional)* If `has_checksum`, check that the xor of `tl.used_size` bytes
-   starting at `tl_base_addr` is 0x0. If not, abort (TL is corrupted).
+#. *(optional)* If `has_checksum`, check that the sum of `tl.size` bytes
+   starting at `tl_base_addr` minus `tl.checksum` is equal to `tl.checksum`. If
+   not, abort (TL is corrupted).
 
 Reading a TL
 ^^^^^^^^^^^^
@@ -361,8 +362,8 @@ Inputs:
 
    #. Use the `te_base_addr` of this tag for the rest of the operation.
 
-   #. If `has_checksum`, xor the `align8(new_data_size + 0x8)` bytes starting at
-      `te_base_addr` with `tl.checksum`.
+   #. If `has_checksum`, Subtract the sum of `align8(new_data_size + 0x8)` bytes
+      starting at `te_base_addr` from `tl.checksum`.
 
    #. Skip the next step (step 2) with all its substeps.
 
@@ -371,13 +372,13 @@ Inputs:
    #. If `tl.total_size - tl.used_size` is smaller than `align8(new_data_size + 0x8)`,
       abort (not enough room to add TE).
 
-   #. If `has_checksum`, xor the 4 bytes from `tl_base_addr + 0x8` with
-      `tl_base_addr + 0xc` from `tl.checksum`.
+   #. If `has_checksum`, subtract the sum of the 4 bytes from
+      `tl_base_addr + 0x8` to `tl_base_addr + 0xc` from `tl.checksum`.
 
    #. Add `align8(new_data_size + 0x8)` to `tl.used_size`.
 
-   #. If `has_checksum`, xor the 4 bytes from `tl_base_addr + 0x8` to
-      `tl_base_addr + 0xc` with `tl.checksum`.
+   #. If `has_checksum`, add the sum of the 4 bytes from `tl_base_addr + 0x8` to
+      `tl_base_addr + 0xc` to `tl.checksum`.
 
 #. Set `te.tag_id` (`te_base_addr + 0x0`) to `new_tag_id`.
 
@@ -387,8 +388,8 @@ Inputs:
 
 #. Copy or generate the TE data into `te_base_addr + 0x8`.
 
-#. If `has_checksum`, xor the `align8(new_data_size + 0x8)` bytes starting at
-   `te_base_addr` with `tl.checksum`.
+#. If `has_checksum`, add the sum of `align8(new_data_size + 0x8)` bytes
+   starting at `te_base_addr` to `tl.checksum`.
 
 #. If an existing XFERLIST_VOID TE was chosen to be overwritten in step 1, and
    `old_void_data_size - new_data_size` is greater or equal to `0x8`:
@@ -396,8 +397,8 @@ Inputs:
    #. Use `te_base_addr + align8(new_data_size + 0x8)` as the new `te_base_addr`
       for a new XFERLIST_VOID tag.
 
-   #. If `has_checksum`, xor the 8 bytes from `te_base_addr` to
-      `te_base_addr + 0x8` with `tl.checksum`.
+   #. If `has_checksum`, subtract the sum of the 8 bytes from `te_base_addr` to
+      `te_base_addr + 0x8` from `tl.checksum`.
 
    #. Set `te.tag_id` (`te_base_addr + 0x0`) to `0x0` (XFERLIST_VOID).
 
@@ -406,8 +407,8 @@ Inputs:
    #. Set `te.data_size` (`te_base_addr + 0x4`) to
       `old_void_data_size - align8(new_data_size) - 0x8`.
 
-   #. If `has_checksum`, xor the 8 bytes from `te_base_addr` to
-      `te_base_addr + 0x8` with `tl.checksum`.
+   #. If `has_checksum`, add the sum of the 8 bytes from `te_base_addr` to
+      `te_base_addr + 0x8` to `tl.checksum`.
 
 Adding a new TE with special data alignment requirement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -439,11 +440,11 @@ Inputs:
 
 #. If `new_alignment` is larger than `tl.alignment`:
 
-   #. If `has_checksum`, xor `tl.alignment` with `tl.checksum`.
+   #. If `has_checksum`, subtract `tl.alignment` from `tl.checksum`.
 
    #. Set `tl.alignment` to `new_alignment`.
 
-   #. If `has_checksum`, xor `tl.alignment` with `tl.checksum`.
+   #. If `has_checksum`, add `tl.alignment` to `tl.checksum`.
 
 Creating a TL
 ^^^^^^^^^^^^^
@@ -472,7 +473,7 @@ Inputs:
 #. If checksums are to be used, set `tl.flags` (`tl_base_addr + 0x10`) to `1`,
    else `0`. This is the value of `has_checksum`.
 
-#. If `has_checksum`, calculate the checksum as the xor of all bytes from
+#. If `has_checksum`, calculate the checksum as the sum of all bytes from
    `tl_base_addr` to `tl_base_addr + tl.hdr_size`, and write the result to
    `tl.checksum`.
 
@@ -498,13 +499,13 @@ Inputs:
 
 #. Copy `tl.used_size` bytes from `tl_base_addr` to `new_tl_base`.
 
-#. If `has_checksum`, xor the 4 bytes from `new_tl_base + 0xc`
-   to `new_tl_base + 0x10` with `tl.checksum` (`new_tl_base + 0x4`).
+#. If `has_checksum`, subtract the sum of the 4 bytes from `new_tl_base + 0xc`
+   to `new_tl_base + 0x10` from `tl.checksum` (`new_tl_base + 0x4`).
 
 #. Set `tl.total_size` (`new_tl_base + 0xc`) to `target_size - (new_tl_base - target_base)`.
 
-#. If `has_checksum`, xor the 4 bytes from `new_tl_base + 0xc` to
-   `new_tl_base + 0x10` with `tl.checksum` (`new_tl_base + 0x4`).
+#. If `has_checksum`, add the sum of the 4 bytes from `new_tl_base + 0xc` to
+   `new_tl_base + 0x10` to `tl.checksum` (`new_tl_base + 0x4`).
 
 
 .. _sec_std_entries:


### PR DESCRIPTION
This reverts commit ae94bd1ff5b5d4a1024782934df8299b4c8d097b, redefining the TL Header checksum field as a sum over all the TL bytes.

!Fix #78 

